### PR TITLE
Goimports tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,239 @@
+# Fork of `Go Tools` to tune `goimports` behavior
+
+This fork is created to fix next issues
+
+- work with 3rd-party packages defined in `local` flag in more strict way
+	- if few packages are provided in `local`, the each group will be intended with new line
+	- groups ordering is the same as provided in `local`
+- ignore user defined empty lines between imports. It allows to receive more predictable ordering
+
+## Download/Install
+
+The easiest way to install is to run `go get -u github.com/nawa/tools/cmd/goimports`
+
+
+## Comparison with standard `goimports`
+
+The next command is used
+
+```bash
+goimports -local="gitlab.internal.com,project-local-package-2,project-local-package-1"
+```
+
+### Comparison of 3rd-party packages indentation and ordering:
+Input:
+
+```go
+package pkg
+
+import (
+	"project-local-package-2/X/Y/B"
+	"other-repo.by/X/Y"
+	"project-local-package-2/X/Y/NotUsed"
+	"fmt"
+	"gitlab.internal.com/X/Y/datastructures"
+	"database/sql"
+	c "gitlab.internal.com/X/Y/C"
+	"gopkg.in/gorp.v1"
+	"bytes"
+	a "gitlab.internal.com/X/Y/A"
+	b "gitlab.internal.com/X/Y/B"
+	b1 "project-local-package-1/X/Y/B"
+	"github.com/lib/pq"
+	a1 "project-local-package-1/X/Y/A"
+	"strconv"
+	"time"
+	nu "other-repo.by/X/NotUsed"
+	"project-local-package-2/X/Y/A"
+	"github.com/pkg/errors"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+Standard `goimports`:
+
+```go
+package pkg
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"gopkg.in/gorp.v1"
+	"other-repo.by/X/Y"
+
+	a "gitlab.internal.com/X/Y/A"
+	b "gitlab.internal.com/X/Y/B"
+	c "gitlab.internal.com/X/Y/C"
+	"gitlab.internal.com/X/Y/datastructures"
+	a1 "project-local-package-1/X/Y/A"
+	b1 "project-local-package-1/X/Y/B"
+	"project-local-package-2/X/Y/A"
+	"project-local-package-2/X/Y/B"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+Tuned `goimports`:
+
+```go
+package pkg
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"gopkg.in/gorp.v1"
+	"other-repo.by/X/Y"
+
+	a "gitlab.internal.com/X/Y/A"
+	b "gitlab.internal.com/X/Y/B"
+	c "gitlab.internal.com/X/Y/C"
+	"gitlab.internal.com/X/Y/datastructures"
+
+	"project-local-package-2/X/Y/A"
+	"project-local-package-2/X/Y/B"
+
+	a1 "project-local-package-1/X/Y/A"
+	b1 "project-local-package-1/X/Y/B"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+### Comparison of ignoring user defined empty lines
+
+Input:
+
+```go
+package pkg
+
+import (
+	"project-local-package-2/X/Y/B"
+	"other-repo.by/X/Y"
+	"project-local-package-2/X/Y/NotUsed"
+	"fmt"
+	"gitlab.internal.com/X/Y/datastructures"
+
+	"database/sql"
+
+	c "gitlab.internal.com/X/Y/C"
+
+	"gopkg.in/gorp.v1"
+
+	"bytes"
+
+	a "gitlab.internal.com/X/Y/A"
+
+	b "gitlab.internal.com/X/Y/B"
+
+	b1 "project-local-package-1/X/Y/B"
+
+	"github.com/lib/pq"
+	a1 "project-local-package-1/X/Y/A"
+
+	"strconv"
+
+	"time"
+	nu "other-repo.by/X/NotUsed"
+
+	"project-local-package-2/X/Y/A"
+
+	"github.com/pkg/errors"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+Standard `goimports`:
+
+```go
+package pkg
+
+import (
+	"fmt"
+
+	"other-repo.by/X/Y"
+
+	"gitlab.internal.com/X/Y/datastructures"
+	"project-local-package-2/X/Y/B"
+
+	"database/sql"
+
+	c "gitlab.internal.com/X/Y/C"
+
+	"gopkg.in/gorp.v1"
+
+	"bytes"
+
+	a "gitlab.internal.com/X/Y/A"
+
+	b "gitlab.internal.com/X/Y/B"
+
+	b1 "project-local-package-1/X/Y/B"
+
+	"github.com/lib/pq"
+
+	a1 "project-local-package-1/X/Y/A"
+
+	"strconv"
+
+	"time"
+
+	"project-local-package-2/X/Y/A"
+
+	"github.com/pkg/errors"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+Tuned `goimports`:
+
+```go
+package pkg
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"gopkg.in/gorp.v1"
+	"other-repo.by/X/Y"
+
+	a "gitlab.internal.com/X/Y/A"
+	b "gitlab.internal.com/X/Y/B"
+	c "gitlab.internal.com/X/Y/C"
+	"gitlab.internal.com/X/Y/datastructures"
+
+	"project-local-package-2/X/Y/A"
+	"project-local-package-2/X/Y/B"
+
+	a1 "project-local-package-1/X/Y/A"
+	b1 "project-local-package-1/X/Y/B"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+```
+
+# Original README
+
 # Go Tools
 
 This subrepository holds the source for various packages and tools that support

--- a/internal/imports/fix.go
+++ b/internal/imports/fix.go
@@ -38,9 +38,9 @@ var importToGroup = []func(env *ProcessEnv, importPath string) (num int, ok bool
 		if env.LocalPrefix == "" {
 			return
 		}
-		for _, p := range strings.Split(env.LocalPrefix, ",") {
+		for i, p := range strings.Split(env.LocalPrefix, ",") {
 			if strings.HasPrefix(importPath, p) || strings.TrimSuffix(p, "/") == importPath {
-				return 3, true
+				return 3 + i, true
 			}
 		}
 		return

--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -515,7 +515,6 @@ c = fmt.Printf
 
 import (
 	"fmt"
-
 	"gu"
 
 	"manypackages.com/packagea"
@@ -606,15 +605,11 @@ var _, _, _, _, _ = fmt.Errorf, io.Copy, strings.Contains, renamed_packagea.A, B
 
 import (
 	"fmt"
-
-	renamed_packagea "manypackages.com/packagea"
-
 	"io"
-
-	. "manypackages.com/packageb"
-
 	"strings"
 
+	renamed_packagea "manypackages.com/packagea"
+	. "manypackages.com/packageb"
 	_ "manypackages.com/packagec"
 )
 
@@ -1116,6 +1111,69 @@ import "math/rand"
 var _, _ = rand.Read, rand.NewZipf
 `,
 	},
+
+	{
+		name: "local_large",
+		in: `package pkg
+
+import (
+	"gopkg.in/gorp.v1"
+
+	a1 "local.com/X/Y/A"
+
+	"bytes"
+
+	"github.com/lib/pq"
+	"other-repo.by/X/Y"
+
+
+	"github.com/pkg/errors"
+	"fmt"
+	b "github.com/local/X/Y/B"
+
+	"project-local-package-1/X/Y/NotUsed"
+
+
+	nu "other-repo.by/X/NotUsed"
+
+	"github.com/local/X/Y/datastructures"
+	b1 "local.com/X/Y/B"
+	c "github.com/local/X/Y/C"
+	"database/sql"
+
+
+	"strconv"
+	a "github.com/local/X/Y/A"
+	"time"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F
+	`,
+		out: `package pkg
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"gopkg.in/gorp.v1"
+	"other-repo.by/X/Y"
+
+	a1 "local.com/X/Y/A"
+	b1 "local.com/X/Y/B"
+
+	a "github.com/local/X/Y/A"
+	b "github.com/local/X/Y/B"
+	c "github.com/local/X/Y/C"
+	"github.com/local/X/Y/datastructures"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F
+`},
 }
 
 func TestSimpleCases(t *testing.T) {
@@ -1782,9 +1840,11 @@ const _ = runtime.GOOS
 import (
 	"runtime"
 
-	"code.org/r/p/expproj"
 	"example.org/pkg"
+
 	"foo.com/bar"
+
+	"code.org/r/p/expproj"
 )
 
 const X = pkg.A

--- a/internal/imports/imports_local_test.go
+++ b/internal/imports/imports_local_test.go
@@ -1,0 +1,166 @@
+package imports
+
+import (
+	"bytes"
+	"fmt"
+	"go/build"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+type importsLocalTestCase struct {
+	options *Options
+
+	imports        []string
+	inputTpl       string
+	ref            string
+	shuffleImports bool
+}
+
+func TestImportsLocal(t *testing.T) {
+	imports := []string{
+		`"bytes"`,
+		`"database/sql"`,
+		`"fmt"`,
+		`"strconv"`,
+		`"time"`,
+		`"github.com/lib/pq"`,
+		`"github.com/pkg/errors"`,
+		`"gopkg.in/gorp.v1"`,
+		`"other-repo.by/X/Y"`,
+		`nu "other-repo.by/X/NotUsed"`,
+		`"gitlab.internal.com/X/Y/datastructures"`,
+		`a "gitlab.internal.com/X/Y/A"`,
+		`b "gitlab.internal.com/X/Y/B"`,
+		`c "gitlab.internal.com/X/Y/C"`,
+		`a1 "project-local-package-1/X/Y/A"`,
+		`b1 "project-local-package-1/X/Y/B"`,
+		`"project-local-package-2/X/Y/A"`,
+		`"project-local-package-2/X/Y/B"`,
+		`"project-local-package-2/X/Y/NotUsed"`,
+	}
+
+	inputTpl := `package pkg
+
+import (
+%s
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+`
+
+	ref := `package pkg
+
+import (
+	"bytes"
+	"database/sql"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"gopkg.in/gorp.v1"
+	"other-repo.by/X/Y"
+
+	a "gitlab.internal.com/X/Y/A"
+	b "gitlab.internal.com/X/Y/B"
+	c "gitlab.internal.com/X/Y/C"
+	"gitlab.internal.com/X/Y/datastructures"
+
+	"project-local-package-2/X/Y/A"
+	"project-local-package-2/X/Y/B"
+
+	a1 "project-local-package-1/X/Y/A"
+	b1 "project-local-package-1/X/Y/B"
+)
+
+var _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ = bytes.Buffer{}, sql.Stmt{}, fmt.Sprint(), strconv.IntSize, time.February, pq.Error{}, errors.StackTrace{}, gorp.DbMap{}, Y.F, datastructures.F, a.F, b.F, c.F, a1.F, b1.F, A.F, B.F
+`
+
+	options := Options{
+		TabWidth:  8,
+		TabIndent: true,
+		Comments:  true,
+		Fragment:  true,
+		Env: &ProcessEnv{
+			GOPATH: build.Default.GOPATH,
+			GOROOT: build.Default.GOROOT,
+		},
+	}
+
+	options.Env.LocalPrefix = "project-local-package-notexist,gitlab.internal.com,project-local-package-notexist2,project-local-package-2,project-local-package-1"
+
+	//-------------------
+
+	N := 1000
+
+	testcases := make([]importsLocalTestCase, N)
+
+	testcases[0] = importsLocalTestCase{
+		options: &options,
+
+		imports:        imports,
+		inputTpl:       inputTpl,
+		ref:            ref,
+		shuffleImports: false,
+	}
+
+	for i := 1; i < N; i++ {
+		testcases[i] = importsLocalTestCase{
+			options: &options,
+
+			imports:        imports,
+			inputTpl:       inputTpl,
+			ref:            ref,
+			shuffleImports: true,
+		}
+	}
+
+	for _, tc := range testcases {
+		err := tc.assertProcessEquals()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (tc *importsLocalTestCase) prepareInput() string {
+	var imps bytes.Buffer
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	if tc.shuffleImports {
+		r.Shuffle(len(tc.imports), func(i int, j int) {
+			tc.imports[i], tc.imports[j] = tc.imports[j], tc.imports[i]
+		})
+	}
+
+	//insert random empty lines
+	for i := 0; i < len(tc.imports); i++ {
+		if r.Int()%2 == 0 {
+			imps.WriteString("\n")
+			if r.Int()%2 == 0 {
+				imps.WriteString("\n")
+			}
+		}
+		imps.WriteString(tc.imports[i])
+		imps.WriteString("\n")
+	}
+
+	return fmt.Sprintf(tc.inputTpl, imps.String())
+}
+
+func (tc *importsLocalTestCase) assertProcessEquals() error {
+	input := tc.prepareInput()
+	b, err := Process("", []byte(input), tc.options)
+	if err != nil {
+		return err
+	}
+
+	if string(b) != tc.ref {
+		return fmt.Errorf("Not equal!\n%s", string(b))
+	}
+
+	return nil
+}

--- a/internal/imports/sortimports.go
+++ b/internal/imports/sortimports.go
@@ -37,13 +37,14 @@ func sortImports(env *ProcessEnv, fset *token.FileSet, f *ast.File) {
 		// Identify and sort runs of specs on successive lines.
 		i := 0
 		specs := d.Specs[:0]
-		for j, s := range d.Specs {
-			if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
-				// j begins a new run.  End this one.
-				specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:j])...)
-				i = j
-			}
-		}
+		// Next lines are commented from the original source code to do not add user defined new lines and to have the same result always
+		// for j, s := range d.Specs {
+		// 	if j > i && fset.Position(s.Pos()).Line > 1+fset.Position(d.Specs[j-1].End()).Line {
+		// 		// j begins a new run.  End this one.
+		// 		specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:j])...)
+		// 		i = j
+		// 	}
+		// }
 		specs = append(specs, sortSpecs(env, fset, f, d.Specs[i:])...)
 		d.Specs = specs
 


### PR DESCRIPTION
imports:
- work with 3rd-party packages defined in `local` flag in more strict way
- ignore user defined empty lines between imports